### PR TITLE
Slight improvement in config/dev.exs

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -15,4 +15,4 @@ config :nerves_hub_user_api,
 config :nerves_hub_link,
   device_api_host: "0.0.0.0",
   device_api_port: 4001,
-  server_name_indication: 'api.nerves-hub.org'
+  server_name_indication: 'device.nerves-hub.org'


### PR DESCRIPTION
Although when I tested the code also worked with api.nerves-hub.org, I think device.nerves-hub.org is more accurate and conveys the meaning for configs more clearly.