### PR TITLE
Update device name to match the README

### DIFF
--- a/lib/poser/configurator.ex
+++ b/lib/poser/configurator.ex
@@ -19,8 +19,8 @@ defmodule Poser.Configurator do
 
   @impl true
   def build(config) do
-    certfile = Path.join("nerves-hub", "poser-x86_64-cert.pem")
-    keyfile = Path.join("nerves-hub", "poser-x86_64-key.pem")
+    certfile = Path.join("nerves-hub", "poser-cert.pem")
+    keyfile = Path.join("nerves-hub", "poser-key.pem")
 
     signer =
       Path.join("nerves-hub", "poser-signer.cert")


### PR DESCRIPTION
Update device name in the configuration to match the README.

Alternately I can adjust the README to create a device named poser-x86_64