### PR TITLE
Override the certificate and key file used by ENV variable

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -7,6 +7,10 @@ config :poser,
   ca_certs: Path.expand("../ssl/#{Mix.env()}", __DIR__),
   target: Mix.target()
 
+config :poser, Poser.Configurator,
+  certfile: "poser-cert.pem",
+  keyfile: "poser-key.pem"
+
 config :nerves, :firmware, rootfs_overlay: "rootfs_overlay"
 
 config :nerves, source_date_epoch: "1613680624"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,5 +1,9 @@
 import Config
 
+config :poser, Poser.Configurator,
+  certfile: {:system, "POSER_CERT", "poser-cert.pem"},
+  keyfile: {:system, "POSER_KEY", "poser-key.pem"}
+
 # API HTTP connection.
 config :nerves_hub_user_api,
   host: "0.0.0.0",

--- a/lib/poser/configurator.ex
+++ b/lib/poser/configurator.ex
@@ -19,8 +19,10 @@ defmodule Poser.Configurator do
 
   @impl true
   def build(config) do
-    certfile = Path.join("nerves-hub", "poser-cert.pem")
-    keyfile = Path.join("nerves-hub", "poser-key.pem")
+    cert_config = Application.get_env(:poser, __MODULE__)
+
+    certfile = Path.join("nerves-hub", config(cert_config[:certfile]))
+    keyfile = Path.join("nerves-hub", config(cert_config[:keyfile]))
 
     signer =
       Path.join("nerves-hub", "poser-signer.cert")
@@ -54,4 +56,8 @@ defmodule Poser.Configurator do
 
     %{config | socket: socket, ssl: ssl}
   end
+
+  defp config({:system, env, default}), do: System.get_env(env, default)
+
+  defp config(value), do: value
 end


### PR DESCRIPTION
This let's you launch multiple poser instances from the same folder as long as the keys are different.