### PR TITLE
Update README for getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ $ mix nerves_key.signer create poser-signer --years-valid 20
 $ cp poser-signer.* ../poser/nerves-hub/
 ```
 
-* Create the device certificates
+* Create the device and device certificates
 
 ```bash
 $ cd poser
+$ mix nerves_hub.device create --identifier poser --tag poser --description "It's a poser device"
 $ mix nerves_hub.device cert create poser --signer-cert nerves-hub/poser-signer.cert --signer-key nerves-hub/poser-signer.key --path nerves-hub/
 ```
 


### PR DESCRIPTION
The README was missing a step for creating the device itself in NervesHub. This adds the missing step that let me connect a new poser device to a local instance.